### PR TITLE
Fix README accuracy, update Copilot instructions, add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "ExPostFacto",
+  "image": "hexpm/elixir:1.18.3-erlang-26.1.2-debian-bookworm-20250113-slim",
+  "postCreateCommand": "mix local.hex --force && mix local.rebar --force && mix deps.get && mix compile",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "JakeBecker.elixir-ls"
+      ]
+    }
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,128 +1,116 @@
 # GitHub Copilot Instructions for ExPostFacto
 
-## Code Formatting and Standards
+## Build & Test Commands
 
-Always run `mix format` after making any code changes to ensure consistent formatting across the codebase. The project uses the standard Elixir formatter configuration defined in `.formatter.exs`.
+- **Format**: `mix format`
+- **Compile (strict)**: `mix compile --warnings-as-errors`
+- **Test**: `mix test`
+- **Docs**: `mix docs`
 
-Follow these Elixir best practices:
+Always run `mix format` after code changes. The project uses `.formatter.exs` with standard Elixir formatting.
 
-- Use descriptive module and function names
-- Include proper `@moduledoc` and `@doc` attributes for all public modules and functions
-- Use `@spec` type annotations for all public functions
-- Follow the Elixir naming conventions (snake_case for functions/variables, PascalCase for modules)
-- Prefer pattern matching over conditional statements when possible
-- Use `with` statements for complex nested operations
-- Keep functions small and focused on a single responsibility
+## Code Standards
+
+- `@moduledoc` and `@doc` on all public modules and functions
+- `@spec` type annotations on all public functions
+- snake_case for functions/variables, PascalCase for modules
+- Prefer pattern matching over conditionals
+- Use `with` for complex nested operations
 - Use `|>` pipe operator for data transformations
-- Handle errors explicitly with `{:ok, result}` and `{:error, reason}` tuples
-- Use `!` suffix for functions that raise exceptions (e.g., `backtest!`)
+- `{:ok, result}` / `{:error, reason}` tuples for error handling
+- `!` suffix for functions that raise (e.g., `backtest!`)
+- Fix all compiler warnings — there should be zero
 
-## Project Structure and Architecture
+## Project Overview
 
-ExPostFacto is a **backtesting library for trading strategies** written in Elixir. The application structure is organized as follows:
+ExPostFacto is a **backtesting library for trading strategies** in Elixir.
+It is pre-1.0 and under active development.
 
-### Core Modules
+## Architecture
 
-- **`ExPostFacto`** (main entry point): Contains the primary `backtest/3` and `backtest!/3` functions that execute trading strategies against historical data
-- **`ExPostFacto.Result`**: Manages backtesting results and statistics compilation, including trade pairs, profit/loss calculations, and performance metrics
-- **`ExPostFacto.DataPoint`**: Represents individual price data points with actions (buy, sell, close_buy, close_sell)
-- **`ExPostFacto.InputData`**: Handles data munging and preprocessing of input market data
-- **`ExPostFacto.Output`**: Contains the final output structure returned from backtesting operations
+### Core Backtest Flow
 
-### Trading Strategy Framework
+1. Market data (OHLC maps or CSV path) → `ExPostFacto.backtest/3`
+2. Data is cleaned/validated → `InputData.munge/1` normalizes each point
+3. Strategy applied to each data point pair via `Enum.chunk_every(2, 1, :discard)`
+4. Strategy returns actions: `:buy`, `:sell`, `:close_buy`, `:close_sell`
+5. `Result.compile/2` builds trade pairs and calculates statistics
+6. Returns `{:ok, %Output{}}` with `result` field containing all metrics
 
-The library supports pluggable trading strategies through a module-function-arguments tuple pattern `{Module, :function, args}`. Example strategies are provided in:
+**Important**: Only **completed round-trip trades** produce P&L. A `:buy` must
+be paired with a `:close_buy` (or `:sell` with `:close_sell`) to form a
+`TradePair`. A buy-and-hold strategy will show $0 P&L and 0 trades.
 
-- **`ExPostFacto.ExampleStrategies.BuyBuyBuy`**: Always buys (for testing)
-- **`ExPostFacto.ExampleStrategies.SellSellSell`**: Always sells (for testing)
-- **`ExPostFacto.ExampleStrategies.Noop`**: No-operation strategy (for testing)
+### Two Strategy Formats
 
-### Trade Statistics Engine
+1. **MFA tuple** `{Module, :function, args}` — simple, stateless:
+   ```elixir
+   def call(data, result) do
+     if data.close > 105.0, do: :close_buy, else: :buy
+   end
+   ```
 
-The `ExPostFacto.TradeStats` namespace contains modules for calculating various performance metrics:
+2. **Strategy behaviour** `{Module, opts}` — stateful, uses `StrategyContext` Agent:
+   ```elixir
+   use ExPostFacto.Strategy
+   def init(opts), do: {:ok, %{}}
+   def next(state), do: {:ok, state}  # use buy(), sell(), data(), position()
+   ```
+   Note: `StrategyContext` is a singleton named Agent, so behaviour strategies
+   cannot run in parallel. The optimizer falls back to sequential for these.
 
-- **`CompilePairs`**: Groups buy/sell actions into trade pairs for analysis
-- **`DrawDown`**: Calculates maximum and average drawdown percentages and durations
-- **`Duration`**: Handles date/time calculations for trade and drawdown durations
-- **`TotalProfitAndLoss`**: Computes cumulative profit and loss from trade pairs
-- **`TradeDuration`**: Calculates maximum and average trade durations
-- **`TradePercentage`**: Determines best, worst, and average trade performance percentages
-- **`TradePair`**: Represents matched enter/exit positions with balance calculations
-- **`WinRate`**: Computes win rate and win count statistics
+### Key Modules
 
-### Application Flow
+| Module | Purpose |
+|--------|---------|
+| `ExPostFacto` | Main entry point: `backtest/3`, `backtest!/3`, `optimize/4`, `backtest_stream/3` |
+| `ExPostFacto.Result` | Result compilation with concurrent `Task.async_stream` for metrics |
+| `ExPostFacto.InputData` | Data normalization (field aliases, timestamp parsing) |
+| `ExPostFacto.DataPoint` | Struct: `{datum, action, index}` |
+| `ExPostFacto.Output` | Final output struct wrapping data + strategy + result |
+| `ExPostFacto.Validation` | OHLC validation, data cleaning, strategy validation |
+| `ExPostFacto.Indicators` | 6 indicators: SMA, EMA, RSI, MACD, Bollinger Bands, ATR |
+| `ExPostFacto.Strategy` | Behaviour macro with `init/1`, `next/1`, helpers |
+| `ExPostFacto.StrategyContext` | Agent holding current data/position for Strategy behaviour |
+| `ExPostFacto.Optimizer` | Grid search, random search, walk-forward analysis |
+| `ExPostFacto.Streaming` | Chunked backtest processing for large datasets |
 
-1. **Data Input**: Market data (OHLC) is fed into the `backtest/3` function
-2. **Strategy Application**: A trading strategy function is applied to each data point
-3. **Action Generation**: Strategy generates actions (`:buy`, `:sell`, `:close_buy`, `:close_sell`)
-4. **Result Compilation**: Trade pairs are compiled and statistics are calculated
-5. **Output Generation**: Final results with comprehensive trading metrics are returned
+### Trade Statistics (`ExPostFacto.TradeStats.*`)
 
-### Key Design Patterns
+- `CompilePairs` — matches enter/exit points into `TradePair` structs
+- `TradePair` — struct with enter/exit points and running balance
+- `TotalProfitAndLoss`, `WinRate`, `DrawDown`, `TradeDuration`, `TradePercentage`
+- `FinancialRatios` — Sharpe, Sortino, Calmar, CAGR, annual volatility
+- `ProfitMetrics` — profit factor, expectancy, gross P&L
+- `SystemQuality` — SQN with Van Tharp interpretation
+- `KellyCriterion` — Kelly %, fractional Kelly, risk of ruin
+- `MarketRisk` — alpha, beta, information ratio (uses simplified estimates, not real benchmark data)
 
-- **Functional Programming**: Heavy use of immutable data structures and pure functions
-- **Pipeline Processing**: Extensive use of the pipe operator for data transformations
-- **Pattern Matching**: Used throughout for control flow and data extraction
-- **Struct-based Data**: Well-defined structs for `Result`, `DataPoint`, `TradePair`, etc.
-- **Error Handling**: Consistent `{:ok, result}` / `{:error, reason}` pattern with bang variants
+### Modules Not Yet Integrated Into Backtest Loop
 
-### Testing Structure
+These modules are implemented and tested but operate standalone — they are
+**not wired into** `backtest/3`:
 
-Tests are organized to mirror the lib structure:
+- `ExPostFacto.Portfolio` — position management, equity tracking
+- `ExPostFacto.Position` — long/short, partial close, P&L tracking
+- `ExPostFacto.Order` — market/limit/stop/stop-limit with fill logic
 
-- Unit tests for individual modules
-- Integration tests for end-to-end backtesting scenarios
-- Test helpers for generating mock market data (`CandleDataHelper`)
+### Roadmap / Known Stubs
 
-### Future Enhancements (TODOs)
+- JSON data loading — returns error asking for Jason library
+- GenStage streaming pipeline — returns `{:error, "not yet implemented"}`
+- Additional technical indicators beyond the current 6
+- Integration of Portfolio/Position/Order into the backtest loop
 
-Based on comments in the code, planned improvements include:
+## Testing Structure
 
-- Making trade statistics calculations concurrent
-- Adding more comprehensive backtesting metrics similar to Python libraries
-- Expanding the strategy framework capabilities
+Tests mirror `lib/` structure. Key test helpers:
 
-## Development Guidelines
+- `CandleDataHelper` — generates mock market data
+- Tests are mostly async (`async: true`)
 
-When contributing to this project:
+## Example Strategies
 
-1. **Always format code** with `mix format` before committing
-2. **Add comprehensive tests** for new functionality
-3. **Include proper documentation** with examples
-4. **Follow the existing architectural patterns** (functional, immutable)
-5. **Use descriptive names** that clearly indicate purpose
-6. **Handle edge cases** explicitly (empty data, nil values, etc.)
-7. **Maintain backward compatibility** when modifying public APIs
-8. **Add type specs** for all public functions
-9. **Consider performance implications** for large datasets
-10. **Test with real market data** when possible
-11. **Fix compiler warnings** there should be no warnings when possible
-
-## Code Examples
-
-### Strategy Implementation
-
-```elixir
-defmodule MyStrategy do
-  @doc "Simple moving average crossover strategy"
-  @spec call(market_data :: map(), result :: ExPostFacto.Result.t()) :: ExPostFacto.action()
-  def call(%{close: price}, %{data_points: data_points}) do
-    # Strategy logic here
-    :buy  # or :sell, :close_buy, :close_sell
-  end
-end
-```
-
-### Usage Pattern
-
-```elixir
-{:ok, output} = ExPostFacto.backtest(
-  market_data,
-  {MyStrategy, :call, []},
-  starting_balance: 10_000.0
-)
-
-IO.inspect(output.result.total_profit_and_loss)
-```
-
-Remember to always run `mix format` and ensure tests pass with `mix test` before submitting any changes.
+- `BuyBuyBuy`, `SellSellSell`, `Noop` — MFA test strategies
+- `SimpleBuyHold`, `SmaStrategy`, `RSIMeanReversionStrategy` — Strategy behaviour
+- `BollingerBandStrategy`, `BreakoutStrategy`, `AdvancedMacdStrategy` — Strategy behaviour

--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ ExPostFacto empowers traders and developers to test their trading strategies aga
 - **🎯 Easy to Use**: Simple API that gets you backtesting in minutes
 - **📊 Professional Grade**: Comprehensive statistics and performance metrics
 - **🔧 Flexible**: Support for simple functions or advanced strategy behaviours
-- **⚡ Fast**: Concurrent optimization and streaming for large datasets
+- **⚡ Fast**: Concurrent optimization for large parameter spaces
 - **🧹 Robust**: Built-in data validation, cleaning, and error handling
-- **📈 Complete**: 20+ technical indicators and optimization algorithms
+- **📈 Growing**: 6 technical indicators with more on the roadmap
 
 ## ✨ Key Features
 
 ### Multiple Input Formats
 
 - **CSV files** - Load data directly from CSV files
-- **JSON** - Parse JSON market data
 - **Lists of maps** - Use runtime data structures
-- **Streaming** - Handle large datasets efficiently
+- **JSON** - 🗺️ _Roadmap_
+- **Streaming** - Handle large datasets with chunked processing
 
 ### Data Validation & Cleaning
 
@@ -37,41 +37,38 @@ ExPostFacto empowers traders and developers to test their trading strategies aga
 - **Simple MFA functions** for quick prototypes
 - **Advanced Strategy behaviour** with state management
 - **Built-in helper functions** - `buy()`, `sell()`, `position()`, etc.
-- **20+ technical indicators** - SMA, EMA, RSI, MACD, Bollinger Bands, and more
+- **6 technical indicators** - SMA, EMA, RSI, MACD, Bollinger Bands, ATR (more on the roadmap)
 
 ### Performance & Optimization
 
 - **Parameter optimization** with grid search, random search, walk-forward analysis
 - **Concurrent processing** for large parameter spaces
-- **Memory-efficient streaming** for massive datasets
-- **Performance profiling** and bottleneck identification
+- **Chunked streaming** for large datasets via `backtest_stream/3`
 
 ### Comprehensive Analytics
 
-- **30+ performance metrics** - Sharpe ratio, CAGR, max drawdown, profit factor
-- **Trade analysis** - Win rate, best/worst trades, trade duration
-- **Risk metrics** - Drawdown analysis, volatility measures
-- **Visual data** - Heatmaps for parameter optimization
+- **45+ result fields** - Total P&L, win rate, drawdown, trade duration, and more
+- **Financial ratios** - Sharpe, Sortino, Calmar, CAGR, profit factor
+- **System quality** - SQN, Kelly criterion, expectancy
+- **Risk metrics** - Drawdown analysis, volatility (market risk metrics use simplified estimates)
 
 See [ENHANCED_DATA_HANDLING_EXAMPLES.md](docs/ENHANCED_DATA_HANDLING_EXAMPLES.md) for detailed usage examples.
 
 ## LiveBook Integration
 
-ExPostFacto works seamlessly with [LiveBook](https://livebook.dev/) for interactive backtesting and analysis:
+ExPostFacto can be used with [LiveBook](https://livebook.dev/) for interactive backtesting and analysis:
 
 ```elixir
 # In LiveBook, install dependencies:
 Mix.install([
-  {:ex_post_facto, "~> 0.2.0"},
-  {:kino, "~> 0.12.0"},
-  {:kino_vega_lite, "~> 0.1.0"}
+  {:ex_post_facto, "~> 0.2.0"}
 ])
 
-# Run interactive backtests with rich visualizations
+# Run interactive backtests
 {:ok, result} = ExPostFacto.backtest(data, {MyStrategy, :call, []})
 ```
 
-See [LiveBook Integration Guide](docs/LIVEBOOK_INTEGRATION.md) for comprehensive examples, interactive forms, and visualization techniques.
+See [LiveBook Integration Guide](docs/LIVEBOOK_INTEGRATION.md) for examples.
 
 ## 📖 Quick Start
 
@@ -89,6 +86,9 @@ end
 
 ### Your First Backtest
 
+ExPostFacto tracks **round-trip trades** — a `:buy` paired with a `:close_buy` — so
+your strategy needs to both enter and exit positions for results to appear.
+
 ```elixir
 # Sample market data
 market_data = [
@@ -97,10 +97,16 @@ market_data = [
   %{open: 106.0, high: 110.0, low: 104.0, close: 108.0, timestamp: "2023-01-03"}
 ]
 
-# Simple buy-and-hold strategy
+# Simple threshold strategy: buy when cheap, close when above target
+defmodule SimpleThresholdStrategy do
+  def call(data, _result) do
+    if data.close > 105.0, do: :close_buy, else: :buy
+  end
+end
+
 {:ok, result} = ExPostFacto.backtest(
   market_data,
-  {ExPostFacto.ExampleStrategies.SimpleBuyHold, []},
+  {SimpleThresholdStrategy, :call, []},
   starting_balance: 10_000.0
 )
 
@@ -181,7 +187,7 @@ end
 
 ## 📈 Technical Indicators
 
-ExPostFacto includes 20+ built-in technical indicators:
+ExPostFacto includes 6 built-in technical indicators (more on the roadmap):
 
 ```elixir
 # Available indicators
@@ -192,6 +198,7 @@ ema_12 = indicator(:ema, prices, 12)
 rsi_14 = indicator(:rsi, prices, 14)
 {macd, signal, histogram} = indicator(:macd, prices)
 {bb_upper, bb_middle, bb_lower} = indicator(:bollinger_bands, prices)
+atr = indicator(:atr, candles, 14)
 
 # Crossover detection
 if crossover?(fast_sma, slow_sma) do
@@ -309,15 +316,14 @@ ExPostFacto includes several example strategies:
 
 ## 🔧 Advanced Features
 
-### Streaming for Large Datasets
+### Chunked Streaming for Large Datasets
 
 ```elixir
-# Handle massive datasets efficiently
+# Handle large datasets with chunked processing
 {:ok, result} = ExPostFacto.backtest_stream(
   "very_large_dataset.csv",
-  {MyStrategy, []},
-  chunk_size: 1000,
-  memory_limit_mb: 100
+  {MyStrategy, :call, []},
+  chunk_size: 1000
 )
 ```
 
@@ -335,10 +341,10 @@ ExPostFacto includes several example strategies:
 )
 ```
 
-### Heatmap Visualization
+### Heatmap Data
 
 ```elixir
-# Generate parameter heatmaps
+# Generate parameter heatmaps from optimization results
 {:ok, optimization_result} = ExPostFacto.optimize(data, MyStrategy, param_ranges)
 {:ok, heatmap} = ExPostFacto.heatmap(optimization_result, :param1, :param2)
 
@@ -352,10 +358,10 @@ IO.inspect(heatmap.scores)  # 2D array of performance scores
 | --------------------- | ------------ | -------------- | ---------- | ------------ |
 | **Language**          | Elixir       | Python         | Python     | C#/Python    |
 | **Concurrency**       | ✅ Native    | ❌             | ❌         | ✅           |
-| **Memory Efficiency** | ✅ Streaming | ❌             | ❌         | ✅           |
 | **Data Validation**   | ✅ Built-in  | ❌             | ❌         | ✅           |
 | **Walk-Forward**      | ✅           | ❌             | ✅         | ✅           |
 | **Easy Setup**        | ✅           | ✅             | ❌         | ❌           |
+| **Indicators**        | 6            | 100+           | 100+       | 100+         |
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
## Summary

Honest up the README, rewrite Copilot instructions to reflect actual architecture, and add a devcontainer for the coding agent.

## README Corrections

| Claim | Before | After |
|-------|--------|-------|
| Technical indicators | "20+" | 6 (SMA, EMA, RSI, MACD, Bollinger Bands, ATR) |
| JSON loading | Listed as supported | Marked as 🗺️ Roadmap |
| Performance profiling | Listed as feature | Removed (doesn't exist) |
| Quick Start example | `SimpleBuyHold` (shows $0) | `SimpleThresholdStrategy` with round-trip trades |
| Analytics | "30+ metrics" | "45+ result fields" (accurate) |
| Comparison table | Claimed ✅ Memory Efficiency | Replaced with honest indicators count |
| LiveBook | "rich visualizations" with Kino | Simplified to basic usage |
| Streaming | "massive datasets", `memory_limit_mb` | "chunked processing" |

## Copilot Instructions Rewrite

- Added build/test commands (`mix format`, `mix test`, `mix compile --warnings-as-errors`)
- Documented round-trip trade pair semantics (critical for understanding output)
- Documented both strategy formats (MFA vs behaviour) and tradeoffs
- Listed all key modules with their purposes
- Noted Portfolio/Position/Order exist but are **not integrated** into backtest loop
- Documented known stubs and roadmap items
- Noted StrategyContext singleton limitation for parallel optimization

## Devcontainer

Added `.devcontainer/devcontainer.json` for Copilot coding agent environment:
- Elixir 1.18.3 + Erlang/OTP 26.1.2 on Debian Bookworm
- Auto-runs `mix deps.get && mix compile` on setup